### PR TITLE
replace use of clojure-env with new api call

### DIFF
--- a/src/deps_ancient/deps_ancient.clj
+++ b/src/deps_ancient/deps_ancient.clj
@@ -5,7 +5,7 @@
             [clojure.string :as str]))
 
 (defn deps-edn []
-  (let [config-files (:config-files (reader/clojure-env))]
+  (let [config-files (reader/default-deps)]
     (println "Checking" (str/join ", " config-files))
     (reader/read-deps config-files)))
 


### PR DESCRIPTION
clojure-env has been deprecated and will be removed. The latest version of tools.deps.alpha has a new method `reader/default-deps`  that can return the set of deps.edn config files that replicates the logic from clj without shelling out.