### PR TITLE
Update codebase to accommodate with latest tools.deps.alpha

### DIFF
--- a/src/deps_ancient/deps_ancient.clj
+++ b/src/deps_ancient/deps_ancient.clj
@@ -7,12 +7,27 @@
 (defn deps-edn []
   (deps/find-edn-maps))
 
+(defn extract-deps [edn-type deps-edn]
+  (if (= edn-type :user-edn)
+    (->> deps-edn
+         :user-edn
+         :aliases
+         vals
+         first
+         :extra-deps)
+    (->> deps-edn
+         edn-type
+         :aliases
+         vals
+         (map :extra-deps)
+         (into (:deps deps-edn))
+         (into {}))))
+
 (defn deps [deps-edn]
-  (->> deps-edn
-       :aliases
-       vals
-       (map :extra-deps)
-       (into (:deps deps-edn))))
+  (let [root (extract-deps :root-edn deps-edn)
+        user (extract-deps :user-edn deps-edn)
+        project (extract-deps :project-edn deps-edn)]
+    (merge root user project)))
 
 (def always-latest? #{"RELEASE" "SNAPSHOT"})
 

--- a/src/deps_ancient/deps_ancient.clj
+++ b/src/deps_ancient/deps_ancient.clj
@@ -1,13 +1,11 @@
 (ns deps-ancient.deps-ancient
   (:require [ancient-clj.core :as ancient]
             [clojure.edn :as edn]
-            [clojure.tools.deps.alpha.reader :as reader]
+            [clojure.tools.deps.alpha :as deps]
             [clojure.string :as str]))
 
 (defn deps-edn []
-  (let [config-files (reader/default-deps)]
-    (println "Checking" (str/join ", " config-files))
-    (reader/read-deps config-files)))
+  (deps/find-edn-maps))
 
 (defn deps [deps-edn]
   (->> deps-edn


### PR DESCRIPTION
As mentioned in #7 the `clojure.tools.deps.alpha.reader` is deprecated as of tools.deps.alpha >= 0.9.745. Here are the changes which take upon that change but, don't overall change the design of deps-ancient.